### PR TITLE
fixing non reproducibility issue with cmaes inverse model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+*~
 
 # Installer logs
 pip-log.txt

--- a/explauto/sensorimotor_model/inverse/cma.py
+++ b/explauto/sensorimotor_model/inverse/cma.py
@@ -2886,7 +2886,7 @@ class CMAEvolutionStrategy(OOOptimizer):
         self.noiseS = 0  # noise "signal"
         self.hsiglist = []
 
-        if not opts['seed']:
+        if opts['seed'] is None:
             np.random.seed()
             six_decimals = (time.time() - 1e6 * (time.time() // 1e6))
             opts['seed'] = 1e5 * np.random.rand() + six_decimals + 1e5 * (time.time() % 1)
@@ -7961,7 +7961,10 @@ class Rotation(object):
         N = x.shape[0]  # can be an array or matrix, TODO: accept also a list of arrays?
         if str(N) not in self.dicMatrices:  # create new N-basis for once and all
             rstate = np.random.get_state()
-            np.random.seed(self.seed) if self.seed else np.random.seed()
+            if self.seed is not None:
+                np.random.seed(self.seed)
+            else:
+                np.random.seed()
             B = np.random.randn(N, N)
             for i in xrange(N):
                 for j in xrange(0, i):

--- a/explauto/sensorimotor_model/inverse/cma.py
+++ b/explauto/sensorimotor_model/inverse/cma.py
@@ -2886,12 +2886,9 @@ class CMAEvolutionStrategy(OOOptimizer):
         self.noiseS = 0  # noise "signal"
         self.hsiglist = []
 
-        if opts['seed'] is None:
-            np.random.seed()
-            six_decimals = (time.time() - 1e6 * (time.time() // 1e6))
-            opts['seed'] = 1e5 * np.random.rand() + six_decimals + 1e5 * (time.time() % 1)
-        opts['seed'] = int(opts['seed'])
-        np.random.seed(opts['seed'])  # CAVEAT: this only seeds np.random
+        if opts['seed'] is not None:
+            opts['seed'] = int(opts['seed'])
+            np.random.seed(opts['seed'])  # CAVEAT: this only seeds np.random
 
         self.sent_solutions = CMASolutionDict()
         self.archive = CMASolutionDict()
@@ -7963,8 +7960,6 @@ class Rotation(object):
             rstate = np.random.get_state()
             if self.seed is not None:
                 np.random.seed(self.seed)
-            else:
-                np.random.seed()
             B = np.random.randn(N, N)
             for i in xrange(N):
                 for j in xrange(0, i):
@@ -8195,7 +8190,8 @@ class FFWrapper(object):
             self.count_evaluations = 0
         def _x_opt(self, dim):
             rstate = np.random.get_state()
-            np.random.seed(self.seed)
+            if self.seed is not None:
+                np.random.seed(self.seed)
             x = self._x_opt_.setdefault(dim,
                                         0 * 3 * np.random.randn(dim))
             np.random.set_state(rstate)

--- a/explauto/sensorimotor_model/inverse/cmamodel.py
+++ b/explauto/sensorimotor_model/inverse/cmamodel.py
@@ -23,6 +23,9 @@ class CMAESInverseModel(OptimizedInverseModel):
         self.upper = list(c[1] for c in self.constraints)
         self.lower = list(c[0] for c in self.constraints)
 
+    def _increment_seed(self):
+        self.seed += 1
+
     def infer_x(self, y):
         """Infer probable x from input y
         @param y  the desired output for infered x.
@@ -43,6 +46,8 @@ class CMAESInverseModel(OptimizedInverseModel):
                            'maxfevals':self.maxfevals,
                            'seed': self.seed})
             result.append((res[1], res[0]))
+
+        self._increment_seed()
 
         return [xi for fi, xi in sorted(result)]
 
@@ -67,5 +72,7 @@ class CMAESInverseModel(OptimizedInverseModel):
                                'maxfevals':self.maxfevals,
                                'seed': self.seed})
                 result.append((res[1], res[0]))
+
+            self._increment_seed()
 
             return sorted(result)[0][1]

--- a/explauto/sensorimotor_model/inverse/cmamodel.py
+++ b/explauto/sensorimotor_model/inverse/cmamodel.py
@@ -12,7 +12,7 @@ class CMAESInverseModel(OptimizedInverseModel):
     name = 'CMAES'
     desc = 'CMA-ES, Covariance Matrix Adaptation Evolution Strategy'
 
-    def __init__(self, dim_x=None, dim_y=None, fmodel=None, cmaes_sigma=0.05, maxfevals=20, seed=0, **kwargs):
+    def __init__(self, dim_x=None, dim_y=None, fmodel=None, cmaes_sigma=0.05, maxfevals=20, seed=None, **kwargs):
         self.cmaes_sigma = cmaes_sigma
         self.maxfevals = maxfevals
         self.seed = seed
@@ -24,7 +24,8 @@ class CMAESInverseModel(OptimizedInverseModel):
         self.lower = list(c[0] for c in self.constraints)
 
     def _increment_seed(self):
-        self.seed += 1
+        if self.seed is not None:
+            self.seed += 1
 
     def infer_x(self, y):
         """Infer probable x from input y

--- a/explauto/sensorimotor_model/inverse/cmamodel.py
+++ b/explauto/sensorimotor_model/inverse/cmamodel.py
@@ -23,10 +23,6 @@ class CMAESInverseModel(OptimizedInverseModel):
         self.upper = list(c[1] for c in self.constraints)
         self.lower = list(c[0] for c in self.constraints)
 
-    def _increment_seed(self):
-        if self.seed is not None:
-            self.seed += 1
-
     def infer_x(self, y):
         """Infer probable x from input y
         @param y  the desired output for infered x.
@@ -47,8 +43,6 @@ class CMAESInverseModel(OptimizedInverseModel):
                            'maxfevals':self.maxfevals,
                            'seed': self.seed})
             result.append((res[1], res[0]))
-
-        self._increment_seed()
 
         return [xi for fi, xi in sorted(result)]
 
@@ -73,7 +67,5 @@ class CMAESInverseModel(OptimizedInverseModel):
                                'maxfevals':self.maxfevals,
                                'seed': self.seed})
                 result.append((res[1], res[0]))
-
-            self._increment_seed()
 
             return sorted(result)[0][1]

--- a/explauto/sensorimotor_model/inverse/cmamodel.py
+++ b/explauto/sensorimotor_model/inverse/cmamodel.py
@@ -1,27 +1,28 @@
 
 from .optimize import OptimizedInverseModel
 from . import cma
-    
+
 
 class CMAESInverseModel(OptimizedInverseModel):
     """
     An inverse model class using CMA-ES optimization routine,
     on an error function computed from the forward model.
     """
-        
+
     name = 'CMAES'
     desc = 'CMA-ES, Covariance Matrix Adaptation Evolution Strategy'
-    
-    def __init__(self, dim_x=None, dim_y=None, fmodel=None, cmaes_sigma=0.05, maxfevals=20, **kwargs):
+
+    def __init__(self, dim_x=None, dim_y=None, fmodel=None, cmaes_sigma=0.05, maxfevals=20, seed=0, **kwargs):
         self.cmaes_sigma = cmaes_sigma
         self.maxfevals = maxfevals
+        self.seed = seed
         OptimizedInverseModel.__init__(self, dim_x, dim_y, fmodel=fmodel, **kwargs)
-        
+
     def _setuplimits(self, constraints):
         OptimizedInverseModel._setuplimits(self, constraints)
         self.upper = list(c[1] for c in self.constraints)
         self.lower = list(c[0] for c in self.constraints)
-        
+
     def infer_x(self, y):
         """Infer probable x from input y
         @param y  the desired output for infered x.
@@ -32,18 +33,19 @@ class CMAESInverseModel(OptimizedInverseModel):
             return self._random_x()
 
         x_guesses = [self._guess_x_simple(y)[0]]
-                
+
         result = []
         for xg in x_guesses:
-            res = cma.fmin(self._error, xg, self.cmaes_sigma, 
+            res = cma.fmin(self._error, xg, self.cmaes_sigma,
                            options={'bounds':[self.lower, self.upper],
                            'verb_log':0,
                            'verb_disp':False,
-                           'maxfevals':self.maxfevals})
+                           'maxfevals':self.maxfevals,
+                           'seed': self.seed})
             result.append((res[1], res[0]))
- 
+
         return [xi for fi, xi in sorted(result)]
-    
+
     def infer_dims(self, x, y, dims_x, dims_y, dims_out):
         """Infer probable output from input x, y
         """
@@ -55,16 +57,15 @@ class CMAESInverseModel(OptimizedInverseModel):
         else:
             _, index = self.fmodel.dataset.nn_dims(x, y, dims_x, dims_y, k=1)
             guesses = [self.fmodel.dataset.get_dims(index[0], dims_out)]
-                    
+
             result = []
             for g in guesses:
-                res = cma.fmin(lambda q:self._error_dims(q, dims_x, dims_y, dims_out), g, self.cmaes_sigma, 
+                res = cma.fmin(lambda q:self._error_dims(q, dims_x, dims_y, dims_out), g, self.cmaes_sigma,
                                options={'bounds':[self.lower, self.upper],
                                'verb_log':0,
                                'verb_disp':False,
-                               'maxfevals':self.maxfevals})
+                               'maxfevals':self.maxfevals,
+                               'seed': self.seed})
                 result.append((res[1], res[0]))
-     
+
             return sorted(result)[0][1]
-                
-            

--- a/explauto/sensorimotor_model/non_parametric.py
+++ b/explauto/sensorimotor_model/non_parametric.py
@@ -11,7 +11,7 @@ from explauto.utils import rand_bounds
 
 
 class NonParametric(SensorimotorModel):
-    """ This class wraps the non-parametric forward and inverse models implemented by Fabien Benureau, in order to fit into the Explauto framework. 
+    """ This class wraps the non-parametric forward and inverse models implemented by Fabien Benureau, in order to fit into the Explauto framework.
         Original code available at https://github.com/humm/models
         Adapted by Sebastien Forestier
     """
@@ -34,14 +34,14 @@ class NonParametric(SensorimotorModel):
     def infer(self, in_dims, out_dims, x):
         if self.t < max(self.model.imodel.fmodel.k, self.model.imodel.k):
             raise ExplautoBootstrapError
-        
+
         if in_dims == self.m_dims and out_dims == self.s_dims:  # forward
             return array(self.model.predict_effect(tuple(x)))
-        
+
         elif in_dims == self.s_dims and out_dims == self.m_dims:  # inverse
             if not self.bootstrapped_s:
                 # If only one distinct point has been observed in the sensory space, then we output a random motor command
-                return rand_bounds(np.array([self.m_mins, 
+                return rand_bounds(np.array([self.m_mins,
                                              self.m_maxs]))[0]
             else:
                 if self.mode == 'explore':
@@ -51,8 +51,8 @@ class NonParametric(SensorimotorModel):
                     res = bounds_min_max(r, self.m_mins, self.m_maxs)
                     return res
                 else:  # exploit'
-                    return array(self.model.infer_order(tuple(x)))                
-            
+                    return array(self.model.infer_order(tuple(x)))
+
         elif out_dims == self.m_dims[len(self.m_dims)/2:]:  # dm = i(M, S, dS)
             if not self.bootstrapped_s:
                 # If only one distinct point has been observed in the sensory space, then we output a random motor command
@@ -62,16 +62,16 @@ class NonParametric(SensorimotorModel):
                 m = x[:self.m_ndims/2]
                 s = x[self.m_ndims/2:][:self.s_ndims/2]
                 ds = x[self.m_ndims/2:][self.s_ndims/2:]
-                self.mean_explore = array(self.model.imodel.infer_dm(m, s, ds))               
-                if self.mode == 'explore': 
+                self.mean_explore = array(self.model.imodel.infer_dm(m, s, ds))
+                if self.mode == 'explore':
                     r = np.random.normal(self.mean_explore, self.sigma_expl[out_dims])
-                    res = bounds_min_max(r, self.m_mins[out_dims], self.m_maxs[out_dims])                
-                    return res       
+                    res = bounds_min_max(r, self.m_mins[out_dims], self.m_maxs[out_dims])
+                    return res
                 else:
                     return self.mean_explore
         else:
             raise NotImplementedError
-                                
+
     def predict_given_context(self, x, c, c_dims):
         return self.model.imodel.fmodel.predict_given_context(x, c, c_dims)
 
@@ -81,12 +81,12 @@ class NonParametric(SensorimotorModel):
         if not self.bootstrapped_s and self.t > 1:
             if not list(s) == list(self.model.imodel.fmodel.dataset.get_y(self.t - 2)):
                 self.bootstrapped_s = True
-                
+
     def update_batch(self, m_list, s_list):
         self.model.add_xy_batch(m_list, s_list)
         self.t += len(m_list)
         self.bootstrapped_s = True
-        
+
     def size(self):
         return self.t
 


### PR DESCRIPTION
Tricky one! For my work, I will run code on a real platform over multiple days. It requires to restart an experiment exaclty as I left it, hence to control the random seed. But the cmamodel and cma code did not handle seed yet. This pull request propose a solution for this. Tested on my system, the cma execution is now reproducible

- problem was call to np.random.seed() without seed due to none provided
- when this happen the seed is set according to some random value from the OS, which we can not control
- seed is now included in cmamodel.py (default to 0) and cma.py code is fixed to accept seed=0 as real seed
- seed is incremented every call so the initial population is not always the same